### PR TITLE
Fix issue in healthcheck.sh for IPv6 addresses

### DIFF
--- a/rootfs/scripts/healthcheck.sh
+++ b/rootfs/scripts/healthcheck.sh
@@ -59,7 +59,7 @@ else
 fi
 
 # Attempt to resolve BEASTHOST into an IP address
-if BEASTIP=$(getent ahosts "$BEASTHOST" | grep "$BEASTHOST" 2> /dev/null | cut -d ' ' -f 1); then
+if BEASTIP=$(getent ahostsv4 "$BEASTHOST" | grep "$BEASTHOST" 2> /dev/null | cut -d ' ' -f 1); then
   :
   #echo "got host via getent"
 elif BEASTIP=$(s6-dnsip4 "$BEASTHOST" 2> /dev/null); then

--- a/rootfs/scripts/healthcheck.sh
+++ b/rootfs/scripts/healthcheck.sh
@@ -59,7 +59,7 @@ else
 fi
 
 # Attempt to resolve BEASTHOST into an IP address
-if BEASTIP=$(getent hosts "$BEASTHOST" 2> /dev/null | cut -d ' ' -f 1); then
+if BEASTIP=$(getent ahosts "$BEASTHOST" | grep "$BEASTHOST" 2> /dev/null | cut -d ' ' -f 1); then
   :
   #echo "got host via getent"
 elif BEASTIP=$(s6-dnsip4 "$BEASTHOST" 2> /dev/null); then


### PR DESCRIPTION
In my case, the `getent hosts` command returns an IPv6 address but `netstat -anp` gives IPv4 addresses, so the last check fails. With this change, the IPv4 address gets resolved correctly.